### PR TITLE
feat: Settings page with data export and account deletion

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 
 from app.api import (
+    account,
     agents,
     auth,
     integrations,
@@ -37,4 +38,5 @@ api_router.include_router(notion_oauth.router, prefix="/integrations", tags=["in
 api_router.include_router(sync.router, prefix="/sync", tags=["sync"])
 api_router.include_router(todos.router, prefix="/todos", tags=["todos"])
 api_router.include_router(waitlist.router, tags=["waitlist"])
+api_router.include_router(account.router, prefix="/account", tags=["account"])
 api_router.include_router(clerk_webhook.router, prefix="/webhooks/clerk", tags=["webhooks"])

--- a/backend/app/api/account.py
+++ b/backend/app/api/account.py
@@ -1,0 +1,97 @@
+"""Account management endpoints: data export, data summary, and account deletion."""
+
+import logging
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.auth.clerk import get_clerk_active_user
+from app.config import get_settings
+from app.database import get_db
+from app.dependencies import get_storage_service
+from app.models.user import User
+from app.services.account_service import AccountService
+from app.storage import StorageService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class DeleteAccountRequest(BaseModel):
+    confirmation: str
+
+
+@router.get("/data-summary")
+async def get_data_summary(
+    current_user: Annotated[User, Depends(get_clerk_active_user)],
+    db: Annotated[Session, Depends(get_db)],
+):
+    """Get a summary of all user data (for deletion confirmation UI)."""
+    summary = await AccountService.get_data_summary(current_user.id, db)
+    return summary
+
+
+@router.post("/export")
+async def export_data(
+    current_user: Annotated[User, Depends(get_clerk_active_user)],
+    db: Annotated[Session, Depends(get_db)],
+    storage: Annotated[StorageService, Depends(get_storage_service)],
+):
+    """Generate and return a ZIP file containing all user data."""
+    try:
+        zip_bytes = await AccountService.generate_data_export(
+            current_user.id, db, storage
+        )
+    except Exception as e:
+        logger.error(f"Failed to generate data export for user {current_user.id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to generate data export",
+        )
+
+    date_str = datetime.utcnow().strftime("%Y-%m-%d")
+    filename = f"rmirror-export-{date_str}.zip"
+
+    return StreamingResponse(
+        iter([zip_bytes]),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.delete("")
+async def delete_account(
+    body: DeleteAccountRequest,
+    current_user: Annotated[User, Depends(get_clerk_active_user)],
+    db: Annotated[Session, Depends(get_db)],
+    storage: Annotated[StorageService, Depends(get_storage_service)],
+):
+    """Permanently delete the user's account and all associated data."""
+    if body.confirmation != "delete my account":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Confirmation phrase must be exactly "delete my account"',
+        )
+
+    settings = get_settings()
+
+    try:
+        summary = await AccountService.delete_account(
+            user_id=current_user.id,
+            db=db,
+            storage=storage,
+            clerk_secret_key=settings.clerk_secret_key,
+        )
+    except Exception as e:
+        logger.error(f"Failed to delete account for user {current_user.id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete account",
+        )
+
+    return {"success": True, "summary": summary}

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -1,0 +1,300 @@
+"""Account service for data export and account deletion."""
+
+import logging
+import re
+import zipfile
+from datetime import datetime
+from io import BytesIO
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.core.pdf_service import PDFService
+from app.models.notebook import Notebook
+from app.models.notebook_page import NotebookPage
+from app.models.page import Page
+from app.models.sync_record import IntegrationConfig, SyncQueue
+from app.models.user import User
+from app.storage import StorageService
+
+logger = logging.getLogger(__name__)
+
+
+class AccountService:
+    """Handles data export and account deletion."""
+
+    @staticmethod
+    async def get_data_summary(user_id: int, db: Session) -> dict:
+        """Return a summary of all data that will be deleted."""
+        user = db.query(User).filter(User.id == user_id).first()
+        if not user:
+            raise ValueError("User not found")
+
+        notebooks = db.query(Notebook).filter(Notebook.user_id == user_id).all()
+        notebook_ids = [n.id for n in notebooks]
+
+        page_count = 0
+        file_count = 0
+        if notebook_ids:
+            pages = db.query(Page).filter(Page.notebook_id.in_(notebook_ids)).all()
+            page_count = len(pages)
+            # Count S3 files: page PDFs + page .rm files + notebook originals + notebook combined PDFs
+            for p in pages:
+                if p.pdf_s3_key:
+                    file_count += 1
+                if p.s3_key:
+                    file_count += 1
+            for n in notebooks:
+                if n.s3_key:
+                    file_count += 1
+                if n.notebook_pdf_s3_key:
+                    file_count += 1
+
+        integrations = (
+            db.query(IntegrationConfig)
+            .filter(IntegrationConfig.user_id == user_id)
+            .all()
+        )
+        integration_names = [i.target_name for i in integrations]
+
+        return {
+            "notebooks": len(notebooks),
+            "pages": page_count,
+            "files": file_count,
+            "integrations": integration_names,
+            "member_since": user.created_at.isoformat() if user.created_at else None,
+            "subscription": user.subscription_tier,
+        }
+
+    @staticmethod
+    async def generate_data_export(
+        user_id: int, db: Session, storage: StorageService
+    ) -> bytes:
+        """Generate a ZIP file containing all user data."""
+        user = db.query(User).filter(User.id == user_id).first()
+        if not user:
+            raise ValueError("User not found")
+
+        notebooks = (
+            db.query(Notebook)
+            .filter(Notebook.user_id == user_id)
+            .order_by(Notebook.full_path, Notebook.visible_name)
+            .all()
+        )
+
+        zip_buffer = BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            # README
+            zf.writestr(
+                "rmirror-export/README.txt",
+                "rMirror Data Export\n"
+                "==================\n\n"
+                "This archive contains all your data from rMirror Cloud.\n\n"
+                "Structure:\n"
+                "  notebooks/     - One folder per notebook with PDF and OCR text\n"
+                "  metadata.json  - Account information and notebook index\n"
+                "  README.txt     - This file\n",
+            )
+
+            notebook_index = []
+            total_pages = 0
+
+            for notebook in notebooks:
+                # Skip folders
+                if notebook.document_type == "folder":
+                    continue
+
+                # Build path from full_path or visible_name
+                safe_name = re.sub(r"[^\w\s-]", "", notebook.visible_name or "notebook")
+                safe_name = re.sub(r"\s+", "_", safe_name)[:50]
+
+                folder_path = ""
+                if notebook.full_path:
+                    # Use full_path for directory structure, sanitize each segment
+                    segments = notebook.full_path.split("/")
+                    safe_segments = []
+                    for seg in segments:
+                        s = re.sub(r"[^\w\s-]", "", seg)
+                        s = re.sub(r"\s+", "_", s)[:50]
+                        if s:
+                            safe_segments.append(s)
+                    if safe_segments:
+                        folder_path = "/".join(safe_segments)
+
+                if folder_path:
+                    notebook_dir = f"rmirror-export/notebooks/{folder_path}"
+                else:
+                    notebook_dir = f"rmirror-export/notebooks/{safe_name}"
+
+                # Get pages in order
+                notebook_pages = (
+                    db.query(NotebookPage, Page)
+                    .join(Page, NotebookPage.page_id == Page.id)
+                    .filter(NotebookPage.notebook_id == notebook.id)
+                    .order_by(NotebookPage.page_number)
+                    .all()
+                )
+
+                nb_page_count = len(notebook_pages)
+                total_pages += nb_page_count
+
+                notebook_index.append(
+                    {
+                        "name": notebook.visible_name,
+                        "uuid": notebook.notebook_uuid,
+                        "type": notebook.document_type,
+                        "pages": nb_page_count,
+                        "path": notebook.full_path,
+                    }
+                )
+
+                if not notebook_pages:
+                    continue
+
+                # Combine page PDFs into single notebook PDF
+                page_pdfs = []
+                for _nb_page, page in notebook_pages:
+                    if page.pdf_s3_key:
+                        try:
+                            pdf_bytes = await storage.download_file(page.pdf_s3_key)
+                            page_pdfs.append(pdf_bytes)
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to download PDF for page {page.id}: {e}"
+                            )
+
+                if page_pdfs:
+                    try:
+                        combined_pdf = PDFService.combine_page_pdfs(page_pdfs)
+                        zf.writestr(f"{notebook_dir}/{safe_name}.pdf", combined_pdf)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to combine PDFs for notebook {notebook.id}: {e}"
+                        )
+
+                # Combine OCR text
+                text_lines = [f"# {notebook.visible_name or 'Untitled Notebook'}\n"]
+                for nb_page, page in notebook_pages:
+                    text_lines.append(f"\n## Page {nb_page.page_number}\n")
+                    if page.ocr_text:
+                        text_lines.append(page.ocr_text)
+                    else:
+                        text_lines.append("[No OCR text]")
+                    text_lines.append("\n---\n")
+
+                text_content = "\n".join(text_lines)
+                zf.writestr(f"{notebook_dir}/{safe_name}.txt", text_content)
+
+            # metadata.json
+            import json
+
+            metadata = {
+                "email": user.email,
+                "full_name": user.full_name,
+                "created_at": user.created_at.isoformat() if user.created_at else None,
+                "export_timestamp": datetime.utcnow().isoformat(),
+                "notebook_count": len(notebook_index),
+                "total_pages": total_pages,
+                "notebooks": notebook_index,
+            }
+            zf.writestr(
+                "rmirror-export/metadata.json",
+                json.dumps(metadata, indent=2, ensure_ascii=False),
+            )
+
+        zip_buffer.seek(0)
+        return zip_buffer.read()
+
+    @staticmethod
+    async def delete_account(
+        user_id: int, db: Session, storage: StorageService, clerk_secret_key: str | None = None
+    ) -> dict:
+        """Permanently delete all user data from all systems."""
+        user = db.query(User).filter(User.id == user_id).first()
+        if not user:
+            raise ValueError("User not found")
+
+        # 1. Cancel in-flight sync queue items
+        cancelled_count = (
+            db.query(SyncQueue)
+            .filter(
+                SyncQueue.user_id == user_id,
+                SyncQueue.status.in_(["pending", "processing"]),
+            )
+            .update({"status": "cancelled"}, synchronize_session="fetch")
+        )
+        logger.info(f"Cancelled {cancelled_count} sync queue items for user {user_id}")
+
+        # 2. Collect S3 keys before deleting DB records
+        notebooks = db.query(Notebook).filter(Notebook.user_id == user_id).all()
+        notebook_ids = [n.id for n in notebooks]
+
+        s3_keys = []
+        for n in notebooks:
+            if n.s3_key:
+                s3_keys.append(n.s3_key)
+            if n.notebook_pdf_s3_key:
+                s3_keys.append(n.notebook_pdf_s3_key)
+
+        if notebook_ids:
+            pages = db.query(Page).filter(Page.notebook_id.in_(notebook_ids)).all()
+            for p in pages:
+                if p.s3_key:
+                    s3_keys.append(p.s3_key)
+                if p.pdf_s3_key:
+                    s3_keys.append(p.pdf_s3_key)
+
+        page_count = len(pages) if notebook_ids else 0
+
+        # 3. Store Clerk ID before deletion
+        clerk_user_id = user.clerk_user_id
+
+        # 4. Delete S3 files (best-effort)
+        deleted_files = 0
+        for key in s3_keys:
+            try:
+                await storage.delete_file(key)
+                deleted_files += 1
+            except Exception as e:
+                logger.warning(f"Failed to delete S3 file {key}: {e}")
+
+        # 5. Delete database records (CASCADE handles all child tables)
+        db.delete(user)
+        db.commit()
+        logger.info(f"Deleted user {user_id} and all associated data from database")
+
+        # 6. Delete from Clerk (best-effort)
+        clerk_deleted = False
+        if clerk_user_id and clerk_secret_key:
+            clerk_deleted = await AccountService._delete_clerk_user(
+                clerk_user_id, clerk_secret_key
+            )
+
+        return {
+            "deleted_notebooks": len(notebooks),
+            "deleted_pages": page_count,
+            "deleted_s3_files": deleted_files,
+            "clerk_deleted": clerk_deleted,
+        }
+
+    @staticmethod
+    async def _delete_clerk_user(clerk_user_id: str, clerk_secret_key: str) -> bool:
+        """Delete user from Clerk via Backend API."""
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.delete(
+                    f"https://api.clerk.com/v1/users/{clerk_user_id}",
+                    headers={"Authorization": f"Bearer {clerk_secret_key}"},
+                )
+                if response.status_code == 200:
+                    logger.info(f"Deleted Clerk user {clerk_user_id}")
+                    return True
+                else:
+                    logger.warning(
+                        f"Failed to delete Clerk user {clerk_user_id}: "
+                        f"status={response.status_code}, body={response.text}"
+                    )
+                    return False
+        except Exception as e:
+            logger.error(f"Error deleting Clerk user {clerk_user_id}: {e}")
+            return False

--- a/backend/tests/unit/test_account_api.py
+++ b/backend/tests/unit/test_account_api.py
@@ -1,0 +1,191 @@
+"""Tests for account API endpoints: data-summary, export, and delete."""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.api.account import router
+from app.database import get_db
+from app.dependencies import get_storage_service
+from app.models.notebook import Notebook
+from app.models.page import OcrStatus, Page
+from app.models.subscription import Subscription, SubscriptionStatus, SubscriptionTier
+from app.models.user import User
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _create_test_app(db: Session, user: User, storage=None):
+    """Build a minimal FastAPI app wired to our account router."""
+    app = FastAPI()
+    app.include_router(router, prefix="/account")
+
+    # Override DB dependency
+    def _get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _get_db
+
+    # Override auth dependency
+    from app.auth.clerk import get_clerk_active_user
+
+    async def _get_user():
+        return user
+
+    app.dependency_overrides[get_clerk_active_user] = _get_user
+
+    # Override storage dependency
+    if storage is None:
+        storage = MagicMock()
+        storage.download_file = AsyncMock(return_value=b"%PDF-1.4 fake")
+        storage.delete_file = AsyncMock(return_value=True)
+
+    app.dependency_overrides[get_storage_service] = lambda: storage
+
+    return TestClient(app)
+
+
+def _create_user(db: Session) -> User:
+    user = User(
+        email="api-test@example.com",
+        full_name="API Test User",
+        clerk_user_id="clerk_api_test",
+        subscription_tier=SubscriptionTier.FREE,
+        is_active=True,
+        is_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# GET /data-summary
+# ---------------------------------------------------------------------------
+
+
+def test_get_data_summary_authenticated(db: Session):
+    """Verify returns correct structure."""
+    user = _create_user(db)
+    client = _create_test_app(db, user)
+
+    response = client.get("/account/data-summary")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "notebooks" in data
+    assert "pages" in data
+    assert "files" in data
+    assert "integrations" in data
+    assert "member_since" in data
+    assert "subscription" in data
+    assert data["notebooks"] == 0
+    assert data["subscription"] == "free"
+
+
+# ---------------------------------------------------------------------------
+# POST /export
+# ---------------------------------------------------------------------------
+
+
+def test_export_authenticated(db: Session):
+    """Verify returns ZIP with correct content-type."""
+    user = _create_user(db)
+    client = _create_test_app(db, user)
+
+    with patch("app.api.account.AccountService.generate_data_export", new_callable=AsyncMock) as mock_export:
+        mock_export.return_value = b"PK\x03\x04fake-zip-content"
+        response = client.post("/account/export")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/zip"
+    assert "rmirror-export-" in response.headers.get("content-disposition", "")
+
+
+# ---------------------------------------------------------------------------
+# DELETE /
+# ---------------------------------------------------------------------------
+
+
+def test_delete_requires_confirmation(db: Session):
+    """Missing/wrong phrase returns 400."""
+    user = _create_user(db)
+    client = _create_test_app(db, user)
+
+    # No body
+    response = client.request("DELETE", "/account", json={})
+    assert response.status_code == 422  # pydantic validation
+
+    # Wrong phrase
+    response = client.request("DELETE", "/account", json={"confirmation": "wrong phrase"})
+    assert response.status_code == 400
+
+
+def test_delete_success(db: Session):
+    """Correct phrase, verify 200 + user gone from DB."""
+    user = _create_user(db)
+    user_id = user.id
+    client = _create_test_app(db, user)
+
+    with patch("app.api.account.AccountService.delete_account", new_callable=AsyncMock) as mock_delete:
+        mock_delete.return_value = {
+            "deleted_notebooks": 0,
+            "deleted_pages": 0,
+            "deleted_s3_files": 0,
+            "clerk_deleted": False,
+        }
+        response = client.request(
+            "DELETE",
+            "/account",
+            json={"confirmation": "delete my account"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert "summary" in data
+
+
+def test_delete_confirmation_case_sensitive(db: Session):
+    """Confirmation phrase is case-sensitive."""
+    user = _create_user(db)
+    client = _create_test_app(db, user)
+
+    response = client.request(
+        "DELETE",
+        "/account",
+        json={"confirmation": "Delete My Account"},
+    )
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Auth requirement test
+# ---------------------------------------------------------------------------
+
+
+def test_endpoints_require_auth(db: Session):
+    """Verify 401/403 without token (using real auth dependency)."""
+    app = FastAPI()
+    app.include_router(router, prefix="/account")
+
+    # Override DB only, NOT auth — so auth is enforced
+    def _get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _get_db
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # All endpoints should fail without auth
+    assert client.get("/account/data-summary").status_code in (401, 403)
+    assert client.post("/account/export").status_code in (401, 403)
+    assert client.request("DELETE", "/account", json={"confirmation": "delete my account"}).status_code in (401, 403)

--- a/backend/tests/unit/test_account_service.py
+++ b/backend/tests/unit/test_account_service.py
@@ -1,0 +1,418 @@
+"""Tests for AccountService: data export, account deletion, and data summary."""
+
+import json
+import zipfile
+from datetime import datetime, timedelta
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.notebook import Notebook
+from app.models.notebook_page import NotebookPage
+from app.models.page import OcrStatus, Page
+from app.models.subscription import Subscription, SubscriptionStatus, SubscriptionTier
+from app.models.sync_record import IntegrationConfig, SyncQueue
+from app.models.user import User
+from app.services.account_service import AccountService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_user(db: Session, email: str = "test@example.com") -> User:
+    user = User(
+        email=email,
+        full_name="Test User",
+        clerk_user_id=f"clerk_{email}",
+        subscription_tier=SubscriptionTier.FREE,
+        is_active=True,
+        is_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _create_notebook(
+    db: Session,
+    user: User,
+    name: str = "Test Notebook",
+    document_type: str = "notebook",
+    full_path: str | None = None,
+    s3_key: str | None = None,
+    notebook_pdf_s3_key: str | None = None,
+) -> Notebook:
+    nb = Notebook(
+        user_id=user.id,
+        notebook_uuid=f"nb-{name}-{datetime.utcnow().timestamp()}",
+        visible_name=name,
+        document_type=document_type,
+        full_path=full_path,
+        s3_key=s3_key,
+        notebook_pdf_s3_key=notebook_pdf_s3_key,
+    )
+    db.add(nb)
+    db.commit()
+    db.refresh(nb)
+    return nb
+
+
+def _create_page(
+    db: Session,
+    notebook: Notebook,
+    page_number: int = 1,
+    ocr_status: str = OcrStatus.COMPLETED,
+    ocr_text: str | None = "Test OCR text",
+    pdf_s3_key: str | None = "pages/test.pdf",
+    s3_key: str | None = "pages/test.rm",
+) -> tuple[Page, NotebookPage]:
+    page = Page(
+        notebook_id=notebook.id,
+        page_uuid=f"page-{page_number}-{datetime.utcnow().timestamp()}",
+        ocr_status=ocr_status,
+        ocr_text=ocr_text,
+        pdf_s3_key=pdf_s3_key,
+        s3_key=s3_key,
+    )
+    db.add(page)
+    db.commit()
+    db.refresh(page)
+
+    nb_page = NotebookPage(
+        notebook_id=notebook.id,
+        page_id=page.id,
+        page_number=page_number,
+    )
+    db.add(nb_page)
+    db.commit()
+    db.refresh(nb_page)
+
+    return page, nb_page
+
+
+def _mock_storage() -> MagicMock:
+    storage = MagicMock()
+    storage.download_file = AsyncMock(return_value=b"%PDF-1.4 fake pdf")
+    storage.delete_file = AsyncMock(return_value=True)
+    return storage
+
+
+# ---------------------------------------------------------------------------
+# get_data_summary tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_data_summary_counts(db: Session):
+    """Verify correct counts are returned."""
+    user = _create_user(db)
+    nb1 = _create_notebook(db, user, "NB1", s3_key="nb1.zip")
+    nb2 = _create_notebook(db, user, "NB2", notebook_pdf_s3_key="nb2.pdf")
+    _create_page(db, nb1, 1)
+    _create_page(db, nb1, 2)
+    _create_page(db, nb2, 1, pdf_s3_key=None, s3_key=None)
+
+    summary = await AccountService.get_data_summary(user.id, db)
+
+    assert summary["notebooks"] == 2
+    assert summary["pages"] == 3
+    # nb1: s3_key(1) + page1: pdf+rm(2) + page2: pdf+rm(2) + nb2: notebook_pdf(1) + page3: 0 = 6
+    assert summary["files"] == 6
+    assert summary["subscription"] == "free"
+    assert summary["member_since"] is not None
+
+
+@pytest.mark.asyncio
+async def test_data_summary_empty_account(db: Session):
+    """User with no notebooks."""
+    user = _create_user(db)
+    summary = await AccountService.get_data_summary(user.id, db)
+
+    assert summary["notebooks"] == 0
+    assert summary["pages"] == 0
+    assert summary["files"] == 0
+    assert summary["integrations"] == []
+
+
+@pytest.mark.asyncio
+async def test_data_summary_with_integrations(db: Session):
+    """Verify integrations are listed."""
+    user = _create_user(db)
+
+    # Need to mock encryption since IntegrationConfig requires it
+    ic = IntegrationConfig(
+        user_id=user.id,
+        target_name="notion",
+        config_encrypted="encrypted-data",
+    )
+    db.add(ic)
+    db.commit()
+
+    summary = await AccountService.get_data_summary(user.id, db)
+    assert summary["integrations"] == ["notion"]
+
+
+# ---------------------------------------------------------------------------
+# generate_data_export tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_data_export(db: Session):
+    """Creates user with 2 notebooks, verifies ZIP structure."""
+    user = _create_user(db)
+    nb1 = _create_notebook(db, user, "My Notebook", full_path="My Notebook")
+    nb2 = _create_notebook(db, user, "Work Notes", full_path="Work/Work Notes")
+
+    _create_page(db, nb1, 1, ocr_text="Page 1 text")
+    _create_page(db, nb1, 2, ocr_text="Page 2 text")
+    _create_page(db, nb2, 1, ocr_text="Work page text")
+
+    storage = _mock_storage()
+
+    with patch("app.services.account_service.PDFService") as mock_pdf:
+        mock_pdf.combine_page_pdfs.return_value = b"%PDF-combined"
+        zip_bytes = await AccountService.generate_data_export(user.id, db, storage)
+
+    # Verify ZIP contents
+    zf = zipfile.ZipFile(BytesIO(zip_bytes))
+    names = zf.namelist()
+
+    assert "rmirror-export/README.txt" in names
+    assert "rmirror-export/metadata.json" in names
+
+    # Check that notebook folders exist
+    nb1_txt = [n for n in names if "My_Notebook" in n and n.endswith(".txt")]
+    nb2_txt = [n for n in names if "Work_Notes" in n and n.endswith(".txt")]
+    assert len(nb1_txt) == 1
+    assert len(nb2_txt) == 1
+
+    # Check metadata
+    metadata = json.loads(zf.read("rmirror-export/metadata.json"))
+    assert metadata["email"] == "test@example.com"
+    assert metadata["notebook_count"] == 2
+    assert metadata["total_pages"] == 3
+
+
+@pytest.mark.asyncio
+async def test_export_empty_account(db: Session):
+    """User with no notebooks - ZIP contains metadata only."""
+    user = _create_user(db)
+    storage = _mock_storage()
+
+    zip_bytes = await AccountService.generate_data_export(user.id, db, storage)
+
+    zf = zipfile.ZipFile(BytesIO(zip_bytes))
+    names = zf.namelist()
+    assert "rmirror-export/metadata.json" in names
+    assert "rmirror-export/README.txt" in names
+
+    metadata = json.loads(zf.read("rmirror-export/metadata.json"))
+    assert metadata["notebook_count"] == 0
+    assert metadata["total_pages"] == 0
+
+
+@pytest.mark.asyncio
+async def test_export_notebook_no_pdfs(db: Session):
+    """Pages without PDFs in storage - text-only export works."""
+    user = _create_user(db)
+    nb = _create_notebook(db, user, "Text Only", full_path="Text Only")
+    _create_page(db, nb, 1, ocr_text="Has text", pdf_s3_key=None, s3_key=None)
+
+    storage = _mock_storage()
+    storage.download_file = AsyncMock(side_effect=FileNotFoundError("Not found"))
+
+    zip_bytes = await AccountService.generate_data_export(user.id, db, storage)
+
+    zf = zipfile.ZipFile(BytesIO(zip_bytes))
+    names = zf.namelist()
+
+    # Should have text file but no PDF
+    txt_files = [n for n in names if n.endswith(".txt") and "Text_Only" in n]
+    pdf_files = [n for n in names if n.endswith(".pdf") and "Text_Only" in n]
+    assert len(txt_files) == 1
+    assert len(pdf_files) == 0
+
+
+@pytest.mark.asyncio
+async def test_export_pages_no_ocr_text(db: Session):
+    """Pages with no OCR text include placeholder."""
+    user = _create_user(db)
+    nb = _create_notebook(db, user, "No OCR", full_path="No OCR")
+    _create_page(db, nb, 1, ocr_text=None, ocr_status=OcrStatus.PENDING)
+
+    storage = _mock_storage()
+
+    with patch("app.services.account_service.PDFService") as mock_pdf:
+        mock_pdf.combine_page_pdfs.return_value = b"%PDF-combined"
+        zip_bytes = await AccountService.generate_data_export(user.id, db, storage)
+
+    zf = zipfile.ZipFile(BytesIO(zip_bytes))
+    txt_files = [n for n in zf.namelist() if n.endswith(".txt") and "No_OCR" in n]
+    assert len(txt_files) == 1
+
+    content = zf.read(txt_files[0]).decode("utf-8")
+    assert "[No OCR text]" in content
+
+
+# ---------------------------------------------------------------------------
+# delete_account tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_account_cascade(db: Session):
+    """Create user with full data graph, delete, verify all tables are empty."""
+    user = _create_user(db)
+    sub = Subscription(
+        user_id=user.id,
+        tier=SubscriptionTier.FREE,
+        status=SubscriptionStatus.ACTIVE,
+        current_period_start=datetime.utcnow(),
+        current_period_end=datetime.utcnow() + timedelta(days=30),
+    )
+    db.add(sub)
+    nb = _create_notebook(db, user, "Del Test")
+    _create_page(db, nb, 1)
+    _create_page(db, nb, 2)
+    db.commit()
+
+    storage = _mock_storage()
+    result = await AccountService.delete_account(user.id, db, storage)
+
+    assert result["deleted_notebooks"] == 1
+    assert result["deleted_pages"] == 2
+
+    # Verify user is gone
+    assert db.query(User).filter(User.id == user.id).first() is None
+    # Verify notebooks are gone
+    assert db.query(Notebook).filter(Notebook.user_id == user.id).count() == 0
+    # Verify subscription is gone
+    assert db.query(Subscription).filter(Subscription.user_id == user.id).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_account_s3_cleanup(db: Session):
+    """Mock storage service, verify delete_file called for each S3 key."""
+    user = _create_user(db)
+    nb = _create_notebook(db, user, "S3 Test", s3_key="nb/orig.zip", notebook_pdf_s3_key="nb/combined.pdf")
+    _create_page(db, nb, 1, pdf_s3_key="pages/p1.pdf", s3_key="pages/p1.rm")
+    _create_page(db, nb, 2, pdf_s3_key="pages/p2.pdf", s3_key=None)
+
+    storage = _mock_storage()
+    await AccountService.delete_account(user.id, db, storage)
+
+    # Expected keys: nb/orig.zip, nb/combined.pdf, pages/p1.pdf, pages/p1.rm, pages/p2.pdf
+    assert storage.delete_file.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_delete_account_clerk_api(db: Session):
+    """Mock httpx, verify Clerk delete API called with correct user ID."""
+    user = _create_user(db)
+    storage = _mock_storage()
+
+    with patch("app.services.account_service.httpx.AsyncClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client.delete = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        result = await AccountService.delete_account(
+            user.id, db, storage, clerk_secret_key="sk_test_123"
+        )
+
+    assert result["clerk_deleted"] is True
+    mock_client.delete.assert_called_once()
+    call_url = mock_client.delete.call_args[0][0]
+    assert user.clerk_user_id.replace("clerk_", "") in call_url or "clerk_" in call_url
+
+
+@pytest.mark.asyncio
+async def test_delete_account_clerk_failure(db: Session):
+    """Clerk API fails, verify deletion still completes (best-effort)."""
+    user = _create_user(db)
+    user_id = user.id
+    storage = _mock_storage()
+
+    with patch("app.services.account_service.httpx.AsyncClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_client.delete = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        result = await AccountService.delete_account(
+            user_id, db, storage, clerk_secret_key="sk_test_123"
+        )
+
+    assert result["clerk_deleted"] is False
+    # User should still be deleted from DB
+    assert db.query(User).filter(User.id == user_id).first() is None
+
+
+@pytest.mark.asyncio
+async def test_delete_account_cancels_sync_jobs(db: Session):
+    """Verify in-flight sync_queue items are cancelled before deletion."""
+    user = _create_user(db)
+
+    # Create sync queue items
+    for sq_status in ["pending", "processing", "completed", "failed"]:
+        sq = SyncQueue(
+            user_id=user.id,
+            item_type="page_text",
+            item_id="item-1",
+            content_hash="hash-1",
+            target_name="notion",
+            status=sq_status,
+        )
+        db.add(sq)
+    db.commit()
+
+    # Verify we have 2 pending/processing items initially
+    active_before = (
+        db.query(SyncQueue)
+        .filter(SyncQueue.user_id == user.id, SyncQueue.status.in_(["pending", "processing"]))
+        .count()
+    )
+    assert active_before == 2
+
+    storage = _mock_storage()
+    await AccountService.delete_account(user.id, db, storage)
+
+    # After deletion, remaining queue items (if any from SQLite not cascading)
+    # should have been cancelled before the user was deleted
+    remaining = db.query(SyncQueue).filter(SyncQueue.user_id == user.id).all()
+    for sq in remaining:
+        # The pending/processing items should have been cancelled
+        assert sq.status in ("cancelled", "completed", "failed")
+
+
+@pytest.mark.asyncio
+async def test_delete_account_no_clerk_key(db: Session):
+    """Without clerk_secret_key, Clerk deletion is skipped."""
+    user = _create_user(db)
+    storage = _mock_storage()
+
+    result = await AccountService.delete_account(user.id, db, storage, clerk_secret_key=None)
+
+    assert result["clerk_deleted"] is False
+
+
+@pytest.mark.asyncio
+async def test_delete_account_user_not_found(db: Session):
+    """Deleting non-existent user raises ValueError."""
+    storage = _mock_storage()
+    with pytest.raises(ValueError, match="User not found"):
+        await AccountService.delete_account(99999, db, storage)

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -3,18 +3,32 @@
 import { useAuth } from '@clerk/nextjs';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useSearchParams } from 'next/navigation';
 import { useState, useEffect, useRef } from 'react';
-import { Check, ArrowRight, Github, Zap, Search as SearchIcon, Cloud, Puzzle } from 'lucide-react';
+import { Check, ArrowRight, Github, Zap, Search as SearchIcon, Cloud, Puzzle, CheckCircle } from 'lucide-react';
 import { MacWindowFrame } from '@/components/MacWindowFrame';
 
 export default function LandingPage() {
   const { isSignedIn } = useAuth();
+  const searchParams = useSearchParams();
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
   const [showError, setShowError] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const [showDeletedBanner, setShowDeletedBanner] = useState(false);
   const heroRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (searchParams.get('deleted') === 'true') {
+      setShowDeletedBanner(true);
+      // Auto-dismiss after 8 seconds
+      const timer = setTimeout(() => setShowDeletedBanner(false), 8000);
+      // Clean up the URL
+      window.history.replaceState({}, '', '/');
+      return () => clearTimeout(timer);
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -57,6 +71,25 @@ export default function LandingPage() {
 
   return (
     <div className="min-h-screen" style={{ background: 'var(--background)' }}>
+      {/* Account deleted banner */}
+      {showDeletedBanner && (
+        <div
+          className="fixed top-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-6 py-3 rounded-lg shadow-lg"
+          style={{ backgroundColor: 'var(--card)', border: '1px solid var(--sage-green)' }}
+        >
+          <CheckCircle className="w-5 h-5 flex-shrink-0" style={{ color: 'var(--sage-green)' }} />
+          <span style={{ fontSize: '0.925em', color: 'var(--warm-charcoal)', fontWeight: 500 }}>
+            Your account has been deleted. All your data has been removed.
+          </span>
+          <button
+            onClick={() => setShowDeletedBanner(false)}
+            style={{ color: 'var(--warm-gray)', background: 'none', border: 'none', cursor: 'pointer', fontSize: '1.25em', lineHeight: 1 }}
+          >
+            &times;
+          </button>
+        </div>
+      )}
+
       {/* Hero Section */}
       <section
         ref={heroRef}

--- a/dashboard/app/settings/page.tsx
+++ b/dashboard/app/settings/page.tsx
@@ -1,0 +1,487 @@
+'use client';
+
+import { useAuth, useUser, UserButton } from '@clerk/nextjs';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Settings, Download, Trash2, AlertTriangle, Menu, Loader2 } from 'lucide-react';
+import Sidebar from '@/components/Sidebar';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://rmirror.io/api/v1';
+
+interface DataSummary {
+  notebooks: number;
+  pages: number;
+  files: number;
+  integrations: string[];
+  member_since: string | null;
+  subscription: string;
+}
+
+export default function SettingsPage() {
+  const { getToken, isSignedIn, signOut } = useAuth();
+  const { user: clerkUser } = useUser();
+  const router = useRouter();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [dataSummary, setDataSummary] = useState<DataSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleteConfirmation, setDeleteConfirmation] = useState('');
+  const [deleteUnderstood, setDeleteUnderstood] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState('');
+
+  const isDevelopmentMode = process.env.NEXT_PUBLIC_DEV_MODE === 'true';
+  const effectiveIsSignedIn = isDevelopmentMode || isSignedIn;
+
+  const getAuthToken = async (): Promise<string> => {
+    if (isDevelopmentMode) {
+      return process.env.NEXT_PUBLIC_DEV_AUTH_TOKEN || localStorage.getItem('dev_auth_token') || '';
+    }
+    const token = await getToken();
+    if (!token) throw new Error('Failed to get authentication token');
+    return token;
+  };
+
+  useEffect(() => {
+    const fetchSummary = async () => {
+      if (!effectiveIsSignedIn) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const token = await getAuthToken();
+        const response = await fetch(`${API_URL}/account/data-summary`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (response.ok) {
+          const data = await response.json();
+          setDataSummary(data);
+        }
+      } catch (err) {
+        console.error('Error fetching data summary:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchSummary();
+  }, [effectiveIsSignedIn]);
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const token = await getAuthToken();
+      const response = await fetch(`${API_URL}/account/export`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!response.ok) {
+        throw new Error('Export failed');
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = response.headers.get('Content-Disposition')?.match(/filename="(.+)"/)?.[1]
+        || `rmirror-export-${new Date().toISOString().split('T')[0]}.zip`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Export error:', err);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setDeleteError('');
+    try {
+      const token = await getAuthToken();
+      const response = await fetch(`${API_URL}/account`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ confirmation: deleteConfirmation }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => null);
+        throw new Error(errorData?.detail || 'Deletion failed');
+      }
+
+      // Sign out and redirect to landing page
+      if (signOut) {
+        await signOut();
+      }
+      router.push('/?deleted=true');
+    } catch (err: any) {
+      setDeleteError(err.message || 'Failed to delete account');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return 'Unknown';
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  const canDelete = deleteConfirmation === 'delete my account' && deleteUnderstood;
+
+  return (
+    <div className="flex h-screen overflow-hidden" style={{ backgroundColor: 'var(--background)' }}>
+      <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      <main className="flex-1 overflow-auto">
+        {/* Header */}
+        <header className="sticky top-0 z-30 border-b bg-white px-6 py-4" style={{ borderColor: 'var(--border)' }}>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <button
+                onClick={() => setSidebarOpen(!sidebarOpen)}
+                className="lg:hidden p-2 hover:bg-gray-100 rounded-lg"
+              >
+                <Menu className="w-5 h-5" />
+              </button>
+              <div>
+                <h1 className="text-2xl font-semibold" style={{ color: 'var(--warm-charcoal)' }}>
+                  Settings
+                </h1>
+                <p className="text-sm" style={{ color: 'var(--warm-gray)' }}>
+                  Manage your account and data
+                </p>
+              </div>
+            </div>
+            {isDevelopmentMode ? (
+              <div style={{
+                fontSize: '0.75em',
+                color: 'var(--warm-gray)',
+                padding: '0.5rem',
+                backgroundColor: 'var(--soft-cream)',
+                borderRadius: 'var(--radius)',
+                border: '1px solid var(--border)',
+              }}>
+                DEV MODE
+              </div>
+            ) : (
+              isSignedIn && <UserButton afterSignOutUrl="/" />
+            )}
+          </div>
+        </header>
+
+        {/* Content */}
+        <div className="p-6" style={{ backgroundColor: 'var(--soft-cream)' }}>
+          {loading ? (
+            <div className="text-center py-12">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 mx-auto" style={{ borderColor: 'var(--terracotta)' }} />
+              <p className="mt-4" style={{ color: 'var(--warm-gray)' }}>Loading settings...</p>
+            </div>
+          ) : (
+            <div className="space-y-6 max-w-3xl mx-auto">
+              {/* Account Information */}
+              <div
+                className="p-6 rounded-lg"
+                style={{ backgroundColor: 'var(--card)', border: '1px solid var(--border)' }}
+              >
+                <div className="flex items-center gap-3 mb-4">
+                  <Settings className="w-5 h-5" style={{ color: 'var(--warm-charcoal)' }} />
+                  <h2 style={{ fontSize: '1.25rem', fontWeight: 600, color: 'var(--warm-charcoal)' }}>
+                    Account Information
+                  </h2>
+                </div>
+
+                <div className="space-y-3">
+                  <div className="flex justify-between items-center py-2 border-b" style={{ borderColor: 'var(--border)' }}>
+                    <span style={{ fontSize: '0.925em', color: 'var(--warm-gray)' }}>Email</span>
+                    <span style={{ fontSize: '0.925em', color: 'var(--warm-charcoal)', fontWeight: 500 }}>
+                      {clerkUser?.primaryEmailAddress?.emailAddress || 'N/A'}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center py-2 border-b" style={{ borderColor: 'var(--border)' }}>
+                    <span style={{ fontSize: '0.925em', color: 'var(--warm-gray)' }}>Name</span>
+                    <span style={{ fontSize: '0.925em', color: 'var(--warm-charcoal)', fontWeight: 500 }}>
+                      {clerkUser?.fullName || 'N/A'}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center py-2 border-b" style={{ borderColor: 'var(--border)' }}>
+                    <span style={{ fontSize: '0.925em', color: 'var(--warm-gray)' }}>Member since</span>
+                    <span style={{ fontSize: '0.925em', color: 'var(--warm-charcoal)', fontWeight: 500 }}>
+                      {formatDate(dataSummary?.member_since ?? null)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center py-2">
+                    <span style={{ fontSize: '0.925em', color: 'var(--warm-gray)' }}>Subscription</span>
+                    <span
+                      className="px-3 py-1 rounded-full"
+                      style={{
+                        fontSize: '0.75em',
+                        fontWeight: 600,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.05em',
+                        backgroundColor: 'var(--sage-green)',
+                        color: 'white',
+                      }}
+                    >
+                      {dataSummary?.subscription || 'free'}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Data Export */}
+              <div
+                className="p-6 rounded-lg"
+                style={{ backgroundColor: 'var(--card)', border: '1px solid var(--border)' }}
+              >
+                <div className="flex items-center gap-3 mb-4">
+                  <Download className="w-5 h-5" style={{ color: 'var(--warm-charcoal)' }} />
+                  <h2 style={{ fontSize: '1.25rem', fontWeight: 600, color: 'var(--warm-charcoal)' }}>
+                    Data Export
+                  </h2>
+                </div>
+
+                <p className="mb-4" style={{ fontSize: '0.925em', color: 'var(--warm-gray)', lineHeight: 1.6 }}>
+                  Download a ZIP file containing all your notebooks as PDFs and OCR text files,
+                  plus account metadata. Your folder structure is preserved.
+                </p>
+
+                {dataSummary && (
+                  <p className="mb-4" style={{ fontSize: '0.875em', color: 'var(--warm-gray)' }}>
+                    Your export will include {dataSummary.notebooks} notebook{dataSummary.notebooks !== 1 ? 's' : ''} with {dataSummary.pages} page{dataSummary.pages !== 1 ? 's' : ''}.
+                  </p>
+                )}
+
+                <button
+                  onClick={handleExport}
+                  disabled={exporting}
+                  className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg transition-colors font-medium"
+                  style={{
+                    backgroundColor: 'var(--sage-green)',
+                    color: 'white',
+                    fontSize: '0.925em',
+                    opacity: exporting ? 0.7 : 1,
+                    cursor: exporting ? 'not-allowed' : 'pointer',
+                  }}
+                >
+                  {exporting ? (
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      Generating export...
+                    </>
+                  ) : (
+                    <>
+                      <Download className="w-4 h-4" />
+                      Download My Data
+                    </>
+                  )}
+                </button>
+              </div>
+
+              {/* Danger Zone */}
+              <div
+                className="p-6 rounded-lg"
+                style={{
+                  backgroundColor: '#fef2f2',
+                  border: '2px solid #fca5a5',
+                }}
+              >
+                <div className="flex items-center gap-3 mb-4">
+                  <AlertTriangle className="w-5 h-5" style={{ color: '#dc2626' }} />
+                  <h2 style={{ fontSize: '1.25rem', fontWeight: 600, color: '#dc2626' }}>
+                    Danger Zone
+                  </h2>
+                </div>
+
+                <p className="mb-2" style={{ fontSize: '0.925em', color: 'var(--warm-charcoal)', lineHeight: 1.6 }}>
+                  Permanently delete your account and all associated data. This action is
+                  <strong> immediate and irreversible</strong>.
+                </p>
+
+                {dataSummary && (
+                  <p className="mb-4" style={{ fontSize: '0.875em', color: 'var(--warm-gray)' }}>
+                    This will delete {dataSummary.notebooks} notebook{dataSummary.notebooks !== 1 ? 's' : ''}, {dataSummary.pages} page{dataSummary.pages !== 1 ? 's' : ''}, {dataSummary.files} stored file{dataSummary.files !== 1 ? 's' : ''}
+                    {dataSummary.integrations.length > 0 && (
+                      <>, and disconnect {dataSummary.integrations.join(', ')} integration{dataSummary.integrations.length !== 1 ? 's' : ''}</>
+                    )}
+                    .
+                  </p>
+                )}
+
+                <button
+                  onClick={() => setShowDeleteModal(true)}
+                  className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg transition-colors font-medium"
+                  style={{
+                    backgroundColor: '#dc2626',
+                    color: 'white',
+                    fontSize: '0.925em',
+                  }}
+                >
+                  <Trash2 className="w-4 h-4" />
+                  Delete Account
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </main>
+
+      {/* Delete Confirmation Modal */}
+      {showDeleteModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+          <div
+            className="w-full max-w-md rounded-xl p-6"
+            style={{ backgroundColor: 'var(--card)', boxShadow: 'var(--shadow-lg, 0 10px 25px rgba(0,0,0,0.15))' }}
+          >
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 rounded-full flex items-center justify-center" style={{ backgroundColor: '#fef2f2' }}>
+                <AlertTriangle className="w-5 h-5" style={{ color: '#dc2626' }} />
+              </div>
+              <h3 style={{ fontSize: '1.125rem', fontWeight: 600, color: 'var(--warm-charcoal)' }}>
+                Delete your account?
+              </h3>
+            </div>
+
+            {/* Download reminder */}
+            <div
+              className="p-3 rounded-lg mb-4 flex items-start gap-3"
+              style={{ backgroundColor: '#fffbeb', border: '1px solid #fcd34d' }}
+            >
+              <Download className="w-4 h-4 mt-0.5 flex-shrink-0" style={{ color: '#d97706' }} />
+              <div>
+                <p style={{ fontSize: '0.875em', color: '#92400e', fontWeight: 500, margin: 0 }}>
+                  Download your data first
+                </p>
+                <button
+                  onClick={() => {
+                    setShowDeleteModal(false);
+                    handleExport();
+                  }}
+                  style={{
+                    fontSize: '0.8em',
+                    color: '#d97706',
+                    textDecoration: 'underline',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    padding: 0,
+                  }}
+                >
+                  Export my data before deleting
+                </button>
+              </div>
+            </div>
+
+            <p className="mb-4" style={{ fontSize: '0.925em', color: 'var(--warm-gray)', lineHeight: 1.6 }}>
+              All your notebooks, pages, files, and integration data will be
+              permanently removed. Your Notion pages will <strong>not</strong> be affected.
+            </p>
+
+            {/* Confirmation input */}
+            <div className="mb-4">
+              <label
+                style={{ fontSize: '0.875em', fontWeight: 500, color: 'var(--warm-charcoal)', display: 'block', marginBottom: '0.5rem' }}
+              >
+                Type <strong>delete my account</strong> to confirm:
+              </label>
+              <input
+                type="text"
+                value={deleteConfirmation}
+                onChange={(e) => setDeleteConfirmation(e.target.value)}
+                placeholder="delete my account"
+                className="w-full px-4 py-2.5 rounded-lg"
+                style={{
+                  border: '1px solid var(--border)',
+                  fontSize: '0.925em',
+                  backgroundColor: 'var(--card)',
+                  color: 'var(--foreground)',
+                }}
+              />
+            </div>
+
+            {/* Checkbox */}
+            <label className="flex items-start gap-3 mb-4 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={deleteUnderstood}
+                onChange={(e) => setDeleteUnderstood(e.target.checked)}
+                className="mt-0.5"
+                style={{ accentColor: '#dc2626' }}
+              />
+              <span style={{ fontSize: '0.875em', color: 'var(--warm-charcoal)' }}>
+                I understand this action is permanent and cannot be undone
+              </span>
+            </label>
+
+            {deleteError && (
+              <div className="mb-4 p-3 rounded-lg" style={{ backgroundColor: '#fef2f2', border: '1px solid #fca5a5' }}>
+                <p style={{ fontSize: '0.875em', color: '#dc2626', margin: 0 }}>{deleteError}</p>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => {
+                  setShowDeleteModal(false);
+                  setDeleteConfirmation('');
+                  setDeleteUnderstood(false);
+                  setDeleteError('');
+                }}
+                className="px-4 py-2.5 rounded-lg transition-colors"
+                style={{
+                  fontSize: '0.925em',
+                  fontWeight: 500,
+                  border: '1px solid var(--border)',
+                  backgroundColor: 'var(--card)',
+                  color: 'var(--warm-charcoal)',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={!canDelete || deleting}
+                className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg transition-colors"
+                style={{
+                  fontSize: '0.925em',
+                  fontWeight: 600,
+                  backgroundColor: canDelete && !deleting ? '#dc2626' : '#e5e7eb',
+                  color: canDelete && !deleting ? 'white' : '#9ca3af',
+                  cursor: canDelete && !deleting ? 'pointer' : 'not-allowed',
+                }}
+              >
+                {deleting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Deleting...
+                  </>
+                ) : (
+                  'Delete My Account Forever'
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/components/Sidebar.tsx
+++ b/dashboard/components/Sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import Image from 'next/image';
-import { HomeIcon, Puzzle, CreditCard, X } from 'lucide-react';
+import { HomeIcon, Puzzle, CreditCard, Settings, X } from 'lucide-react';
 import { useAuth } from '@clerk/nextjs';
 import { useEffect, useState } from 'react';
 import { getAgentStatus, type AgentStatus } from '@/lib/api';
@@ -145,6 +145,19 @@ export default function Sidebar({ open = true, onClose }: SidebarProps) {
           >
             <CreditCard className="w-5 h-5" />
             Billing
+          </Link>
+          <Link
+            href="/settings"
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all"
+            style={{
+              backgroundColor: isActive('/settings') ? 'var(--primary)' : 'transparent',
+              color: isActive('/settings') ? 'var(--primary-foreground)' : 'var(--warm-charcoal)',
+              fontSize: '0.925em',
+              fontWeight: 500
+            }}
+          >
+            <Settings className="w-5 h-5" />
+            Settings
           </Link>
         </div>
 


### PR DESCRIPTION
## Summary

- **Backend**: `AccountService` with data export (ZIP with PDFs + OCR text), account deletion (S3 cleanup + DB cascade + Clerk API), and data summary endpoint
- **Backend**: Account API at `/v1/account/` — `GET /data-summary`, `POST /export`, `DELETE /` (requires "delete my account" confirmation phrase)
- **Backend**: Enhanced Clerk webhook `handle_user_deleted()` to perform full cleanup when deletion is initiated from Clerk dashboard (not just soft-delete)
- **Dashboard**: Settings page with Account Info, Data Export, and Danger Zone sections
- **Dashboard**: Delete confirmation modal with download reminder, phrase input, checkbox
- **Dashboard**: Settings link in Sidebar, `?deleted=true` toast on landing page
- **Tests**: 20 new tests (`test_account_service.py` + `test_account_api.py`) — 246 total, 0 failures

### Key design decisions
- No grace period — immediate, irreversible deletion
- Leave Notion pages alone, only revoke OAuth token
- Export: ZIP with multi-page PDF + .txt per notebook, preserving folder hierarchy
- Deletion order: cancel sync jobs → collect S3 keys → delete S3 → `db.delete(user)` (CASCADE) → delete Clerk user
- Webhook loop prevention: API deletes DB first → Clerk webhook finds no user → no-op

## Test plan

- [ ] Run backend tests: `cd backend && poetry run pytest -x -q --ignore=test_notion_properties.py`
- [ ] Verify Settings page renders at `/settings` with account info
- [ ] Test data export download — verify ZIP contains expected PDF + TXT structure
- [ ] Test deletion flow — confirmation modal, phrase input, checkbox, button enable/disable
- [ ] Test deletion with wrong phrase — verify 400 rejection
- [ ] Verify `?deleted=true` toast on landing page after deletion
- [ ] Verify Settings link in Sidebar navigation
- [ ] Test Clerk-initiated deletion via webhook (user deleted from Clerk dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)